### PR TITLE
Change set_termios handler to take const arg

### DIFF
--- a/driver/ch341.c
+++ b/driver/ch341.c
@@ -68,7 +68,7 @@ static DEFINE_IDR(ch341_minors);
 static DEFINE_MUTEX(ch341_minors_lock);
 
 static void ch341_tty_set_termios(struct tty_struct *tty,
-                                  struct ktermios *termios_old);
+                                  const struct ktermios *termios_old);
 
 /*
  * ch341_minors accessors
@@ -1077,7 +1077,7 @@ static int ch341_get(unsigned int baval,
 }
 
 static void ch341_tty_set_termios(struct tty_struct *tty,
-                                  struct ktermios *termios_old)
+                                  const struct ktermios *termios_old)
 {
     struct ch341 *ch341 = tty->driver_data;
     struct ktermios *termios = &tty->termios;


### PR DESCRIPTION
The `set_termios()` handler was changed to take `const` old ktermios in 6.1 (https://github.com/torvalds/linux/commit/a8c11c1520347be74b02312d10ef686b01b525f1), this is updating the code to reflect that.