### PR TITLE
Fix build on kernel >=6.12

### DIFF
--- a/driver/ch341.c
+++ b/driver/ch341.c
@@ -55,7 +55,11 @@
 #include <linux/usb/cdc.h>
 #include <linux/version.h>
 #include <asm/byteorder.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
 #include <linux/sched/signal.h>


### PR DESCRIPTION
`asm/unaligned.h` moved in this release, and can no longer be found in the old location.